### PR TITLE
Implement CLI and orchestrator

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,7 @@ coint2 = "coint2.cli:main"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+[tool.mypy]
+python_version = "3.10"
+ignore_missing_imports = true
+

--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -1,4 +1,4 @@
-import pandas as pd
+import pandas as pd  # type: ignore
 from pathlib import Path
 from typing import List
 

--- a/src/coint2/core/math_utils.py
+++ b/src/coint2/core/math_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pandas as pd
+import pandas as pd  # type: ignore
 
 
 def rolling_beta(y: pd.Series, x: pd.Series, window: int) -> pd.Series:

--- a/src/coint2/core/performance.py
+++ b/src/coint2/core/performance.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import numpy as np
-import pandas as pd
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
 
 
 TRADING_DAYS = 252

--- a/src/coint2/engine/backtest_engine.py
+++ b/src/coint2/engine/backtest_engine.py
@@ -1,1 +1,46 @@
-pass
+"""Simple pair backtester stub used by the CLI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+import pandas as pd  # type: ignore
+
+from coint2.core.math_utils import rolling_zscore
+from coint2.core.performance import max_drawdown, sharpe_ratio
+from coint2.utils.config import BacktestConfig
+
+
+@dataclass
+class PairBacktester:
+    """Very lightweight pair trading backtester.
+
+    This implementation is intentionally simplistic and serves as a
+    placeholder until the full engine is implemented in another task.
+    """
+
+    data: pd.DataFrame
+    config: BacktestConfig
+
+    def run(self) -> Dict[str, float]:
+        """Execute a naive mean reversion strategy and return metrics."""
+
+        s1, s2 = self.data.columns[:2]
+        spread = self.data[s1] - self.data[s2]
+        z = rolling_zscore(spread, self.config.rolling_window)
+
+        long = z < -self.config.zscore_threshold
+        short = z > self.config.zscore_threshold
+        positions = long.astype(int) - short.astype(int)
+
+        returns = spread.diff().shift(-1)
+        pnl = (positions * returns).dropna()
+
+        metrics = {
+            "cumulative_return": pnl.sum(),
+            "sharpe": sharpe_ratio(pnl),
+            "max_drawdown": max_drawdown(pnl.cumsum()),
+        }
+        return metrics
+

--- a/src/coint2/pipeline/orchestrator.py
+++ b/src/coint2/pipeline/orchestrator.py
@@ -1,1 +1,56 @@
-pass
+"""Pipeline orchestrator tying together scanning and backtesting."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from coint2.core.data_loader import DataHandler
+from coint2.engine.backtest_engine import PairBacktester
+from coint2.pipeline.pair_scanner import find_cointegrated_pairs
+from coint2.utils.config import CONFIG
+from coint2.utils.logging_utils import get_logger
+
+
+def run_full_pipeline() -> List[Dict[str, object]]:
+    """Execute scanning and backtesting for all detected pairs."""
+
+    logger = get_logger("orchestrator")
+    cfg = CONFIG
+
+    handler = DataHandler(
+        cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct
+    )
+
+    logger.info("Loading data for %s days", cfg.pair_selection.lookback_days)
+    data = handler.load_all_data_for_period(cfg.pair_selection.lookback_days)
+    if data.empty:
+        logger.warning("No data available to scan")
+        return []
+
+    logger.info("Scanning for cointegrated pairs")
+    pairs = find_cointegrated_pairs(
+        data, cfg.pair_selection.coint_pvalue_threshold
+    )
+    logger.info("Found %d pairs", len(pairs))
+
+    results_dir = Path(cfg.results_dir)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    all_metrics: List[Dict[str, object]] = []
+    for s1, s2 in pairs:
+        logger.info("Backtesting %s-%s", s1, s2)
+        pair_data = handler.load_pair_data(s1, s2)
+        bt = PairBacktester(pair_data, cfg.backtest)
+        metrics = bt.run()
+        logger.info("Metrics for %s-%s: %s", s1, s2, metrics)
+
+        metrics_path = results_dir / f"{s1}_{s2}_metrics.json"
+        with metrics_path.open("w", encoding="utf-8") as f:
+            json.dump(metrics, f)
+
+        all_metrics.append({"pair": (s1, s2), **metrics})
+
+    return all_metrics
+

--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -1,9 +1,9 @@
 from itertools import combinations
 from typing import List, Tuple
 
-import pandas as pd
-from joblib import Parallel, delayed
-from statsmodels.tsa.stattools import coint
+import pandas as pd  # type: ignore
+from joblib import Parallel, delayed  # type: ignore
+from statsmodels.tsa.stattools import coint  # type: ignore
 
 
 def _coint_test(series1: pd.Series, series2: pd.Series) -> float:

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -1,10 +1,9 @@
 """Configuration utilities using Pydantic models."""
 
 from pathlib import Path
-from typing import Any
 
-import yaml
-from pydantic import BaseModel, DirectoryPath
+import yaml  # type: ignore
+from pydantic import BaseModel, DirectoryPath  # type: ignore
 
 
 class PairSelectionConfig(BaseModel):


### PR DESCRIPTION
## Summary
- implement minimal PairBacktester
- add run_full_pipeline orchestrator
- create CLI with `scan`, `backtest`, and `run-pipeline` commands
- adjust config and imports for mypy
- configure mypy

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685efcf680a48331a37c3e45c9693c1b