### PR TITLE
Fix PairBacktester usage in orchestrator and CLI

### DIFF
--- a/src/coint2/cli.py
+++ b/src/coint2/cli.py
@@ -43,8 +43,13 @@ def backtest(pair: str) -> None:
     s1, s2 = [p.strip() for p in pair.split(",")]
     handler = DataHandler(cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct)
     data = handler.load_pair_data(s1, s2)
-    bt = PairBacktester(data, cfg.backtest)
-    metrics = bt.run()
+    bt = PairBacktester(
+        data,
+        cfg.backtest.rolling_window,
+        cfg.backtest.zscore_threshold,
+    )
+    bt.run()
+    metrics = bt.get_performance_metrics()
     for k, v in metrics.items():
         click.echo(f"{k}: {v}")
 

--- a/src/coint2/pipeline/orchestrator.py
+++ b/src/coint2/pipeline/orchestrator.py
@@ -42,8 +42,13 @@ def run_full_pipeline() -> List[Dict[str, object]]:
     for s1, s2 in pairs:
         logger.info("Backtesting %s-%s", s1, s2)
         pair_data = handler.load_pair_data(s1, s2)
-        bt = PairBacktester(pair_data, cfg.backtest)
-        metrics = bt.run()
+        bt = PairBacktester(
+            pair_data,
+            cfg.backtest.rolling_window,
+            cfg.backtest.zscore_threshold,
+        )
+        bt.run()
+        metrics = bt.get_performance_metrics()
         logger.info("Metrics for %s-%s: %s", s1, s2, metrics)
 
         metrics_path = results_dir / f"{s1}_{s2}_metrics.json"


### PR DESCRIPTION
## Summary
- properly initialize `PairBacktester` in pipeline orchestrator
- update CLI to use new `PairBacktester` parameters

## Testing
- `ruff check src tests`
- `mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f0a29418c8331acfafdf590eb5ebe