### PR TITLE
Refactor DataHandler for partitioned parquet datasets

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -1,4 +1,4 @@
-data_dir: "data"
+data_dir: "data_optimized"
 results_dir: "results"
 pair_selection:
   lookback_days: 90

--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -7,44 +7,72 @@ class DataHandler:
     """Utility class for loading local parquet price files."""
 
     def __init__(self, data_dir: Path, timeframe: str, fill_limit_pct: float) -> None:
-        self.data_dir = Path(data_dir) / timeframe
+        self.data_dir = Path(data_dir)
+        # timeframe kept for metadata compatibility but no longer used in path
+        self.timeframe = timeframe
         self.fill_limit_pct = fill_limit_pct
         self.data_dir.mkdir(parents=True, exist_ok=True)
+        self._all_data_cache: pd.DataFrame | None = None
 
     def get_all_symbols(self) -> List[str]:
-        """Return list of symbols based on parquet file names."""
-        return [p.stem for p in sorted(self.data_dir.glob("*.parquet"))]
+        """Return list of symbols based on partition directory names."""
+        if not self.data_dir.exists():
+            return []
 
-    def _load_symbol_data(self, symbol: str) -> pd.DataFrame:
-        path = self.data_dir / f"{symbol}.parquet"
-        df = pd.read_parquet(path)
-        if "timestamp" in df.columns:
-            df = df.set_index("timestamp")
-        df.index = pd.to_datetime(df.index)
-        df = df.sort_index()
-        return df[["close"]].rename(columns={"close": symbol})
+        symbols = []
+        for path in self.data_dir.iterdir():
+            if path.is_dir() and path.name.startswith("symbol="):
+                symbols.append(path.name.replace("symbol=", ""))
+        return sorted(symbols)
+
+    def _load_full_dataset(self) -> pd.DataFrame:
+        """Load the entire partitioned dataset and cache the result."""
+        if self._all_data_cache is not None:
+            return self._all_data_cache
+
+        if not self.data_dir.exists():
+            self._all_data_cache = pd.DataFrame()
+            return self._all_data_cache
+
+        full_df = pd.read_parquet(self.data_dir, engine="pyarrow")
+
+        if "timestamp" in full_df.columns:
+            full_df = full_df.set_index("timestamp")
+
+        full_df.index = pd.to_datetime(full_df.index)
+        full_df = full_df.sort_index()
+
+        self._all_data_cache = full_df
+        return full_df
 
     def load_all_data_for_period(self, lookback_days: int) -> pd.DataFrame:
         """Load close prices for all symbols for the given lookback period."""
-        all_symbols = self.get_all_symbols()
-        dfs = []
-        for sym in all_symbols:
-            df = self._load_symbol_data(sym)
-            if lookback_days:
-                end = df.index.max()
-                start = end - pd.Timedelta(days=lookback_days)
-                df = df.loc[df.index >= start]
-            dfs.append(df)
-        if not dfs:
+        full_df = self._load_full_dataset()
+        if full_df.empty:
             return pd.DataFrame()
-        return pd.concat(dfs, axis=1).sort_index()
+
+        end_date = full_df.index.max()
+        start_date = end_date - pd.Timedelta(days=lookback_days)
+
+        filtered_df = full_df[full_df.index >= start_date]
+        wide = filtered_df.pivot_table(index=filtered_df.index, columns="symbol", values="close")
+        return wide
 
     def load_pair_data(self, symbol1: str, symbol2: str) -> pd.DataFrame:
         """Load and align data for two symbols."""
-        df1 = self._load_symbol_data(symbol1)
-        df2 = self._load_symbol_data(symbol2)
-        df = pd.concat([df1, df2], axis=1)
-        limit = int(len(df) * self.fill_limit_pct)
-        df = df.sort_index()
-        df = df.ffill(limit=limit).bfill(limit=limit)
-        return df.dropna()
+        full_df = self._load_full_dataset()
+        if full_df.empty:
+            return pd.DataFrame()
+
+        pair_df = full_df[full_df["symbol"].isin([symbol1, symbol2])]
+        wide_df = pair_df.pivot_table(index=pair_df.index, columns="symbol", values="close")
+
+        if wide_df.empty:
+            return pd.DataFrame()
+
+        freq = pd.infer_freq(wide_df.index) or "D"
+        wide_df = wide_df.asfreq(freq)
+        limit = int(len(wide_df) * self.fill_limit_pct)
+        wide_df = wide_df.ffill(limit=limit).bfill(limit=limit)
+
+        return wide_df[[symbol1, symbol2]].dropna()

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -8,12 +8,14 @@ from coint2.pipeline.pair_scanner import find_cointegrated_pairs
 def create_parquet_files(tmp_path: Path) -> None:
     idx = pd.date_range('2021-01-01', periods=20, freq='D')
     a = pd.Series(range(20), index=idx)
-    b = a + 0.1  # cointegrated
+    b = a + 0.1  # cointegrated with A
     c = pd.Series(range(20, 0, -1), index=idx)
+
     for sym, series in [('A', a), ('B', b), ('C', c)]:
+        part_dir = tmp_path / f'symbol={sym}' / 'year=2021' / 'month=01'
+        part_dir.mkdir(parents=True, exist_ok=True)
         df = pd.DataFrame({'timestamp': idx, 'close': series})
-        (tmp_path / '1d').mkdir(parents=True, exist_ok=True)
-        df.to_parquet(tmp_path / '1d' / f'{sym}.parquet')
+        df.to_parquet(part_dir / 'data.parquet')
 
 
 def test_find_cointegrated_pairs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- refactor DataHandler to read partitioned parquet dataset directories
- keep timeframe for metadata but remove from file path usage
- adjust configuration to use `data_optimized` root directory
- update integration test for pair scanner to build partitioned test data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f152f7e788331938cea0cecda4193