### PR TITLE
Add Dask dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ scipy = "*"
 # ↓↓↓ ЭТИ ЗАВИСИМОСТИ МЫ БЕРЕМ ИЗ ВЕТКИ CODEX ↓↓↓
 pyarrow = "*"
 statsmodels = "*"
+dask = {extras = ["dataframe"], version = "*"} # Устанавливаем dask с поддержкой DataFrame
+dask-expr = "*" # Нужен для read_parquet в новых версиях
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
## Summary
- include Dask with dataframe support and `dask-expr` in pyproject

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f18f51d688331a2d0173825764772