### PR TITLE
Refactor pair scanner to use Dask

### DIFF
--- a/src/coint2/cli.py
+++ b/src/coint2/cli.py
@@ -24,8 +24,11 @@ def scan() -> None:
     logger = get_logger("scan")
     cfg = CONFIG
     handler = DataHandler(cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct)
-    data = handler.load_all_data_for_period(cfg.pair_selection.lookback_days)
-    pairs = find_cointegrated_pairs(data, cfg.pair_selection.coint_pvalue_threshold)
+    pairs = find_cointegrated_pairs(
+        handler,
+        cfg.pair_selection.lookback_days,
+        cfg.pair_selection.coint_pvalue_threshold,
+    )
     if not pairs:
         click.echo("No cointegrated pairs found")
         return

--- a/src/coint2/pipeline/orchestrator.py
+++ b/src/coint2/pipeline/orchestrator.py
@@ -23,15 +23,11 @@ def run_full_pipeline() -> List[Dict[str, object]]:
         cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct
     )
 
-    logger.info("Loading data for %s days", cfg.pair_selection.lookback_days)
-    data = handler.load_all_data_for_period(cfg.pair_selection.lookback_days)
-    if data.empty:
-        logger.warning("No data available to scan")
-        return []
-
     logger.info("Scanning for cointegrated pairs")
     pairs = find_cointegrated_pairs(
-        data, cfg.pair_selection.coint_pvalue_threshold
+        handler,
+        cfg.pair_selection.lookback_days,
+        cfg.pair_selection.coint_pvalue_threshold,
     )
     logger.info("Found %d pairs", len(pairs))
 

--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -1,9 +1,10 @@
 from itertools import combinations
 from typing import List, Tuple
 
-import pandas as pd  # type: ignore
-from joblib import Parallel, delayed  # type: ignore
-from statsmodels.tsa.stattools import coint  # type: ignore
+import pandas as pd
+import dask
+from dask import delayed
+from statsmodels.tsa.stattools import coint
 
 
 def _coint_test(series1: pd.Series, series2: pd.Series) -> float:
@@ -12,15 +13,32 @@ def _coint_test(series1: pd.Series, series2: pd.Series) -> float:
     return pvalue
 
 
-def find_cointegrated_pairs(data: pd.DataFrame, p_value_threshold: float) -> List[Tuple[str, str]]:
-    """Find cointegrated pairs among columns of the provided data."""
-    symbols = list(data.columns)
-    pairs = list(combinations(symbols, 2))
+@delayed
+def _test_pair_for_coint(pair_data: pd.DataFrame, p_value_threshold: float) -> Tuple[str, str] | None:
+    """Lazy test for a single pair using already loaded price data."""
+    if pair_data.empty or len(pair_data.columns) < 2:
+        return None
 
-    def check_pair(pair: Tuple[str, str]):
-        s1, s2 = pair
-        pvalue = _coint_test(data[s1].dropna(), data[s2].dropna())
-        return pair if pvalue < p_value_threshold else None
+    s1, s2 = pair_data.columns
+    pvalue = _coint_test(pair_data[s1].dropna(), pair_data[s2].dropna())
+    return (s1, s2) if pvalue < p_value_threshold else None
 
-    results = Parallel(n_jobs=-1)(delayed(check_pair)(p) for p in pairs)
+
+def find_cointegrated_pairs(handler, lookback_days: int, p_value_threshold: float) -> List[Tuple[str, str]]:
+    """Generate and compute dask tasks to find cointegrated pairs."""
+    all_symbols = handler.get_all_symbols()
+    all_pairs = list(combinations(all_symbols, 2))
+
+    lazy_results = []
+    for s1, s2 in all_pairs:
+        pair_df = handler.load_pair_data(s1, s2)
+        if not pair_df.empty:
+            end = pair_df.index.max()
+            start = end - pd.Timedelta(days=lookback_days)
+            pair_df = pair_df[pair_df.index >= start]
+
+        task = _test_pair_for_coint(pair_df, p_value_threshold)
+        lazy_results.append(task)
+
+    results = dask.compute(*lazy_results, scheduler="processes")
     return [r for r in results if r is not None]


### PR DESCRIPTION
## Summary
- use `dask.delayed` to evaluate cointegration tests lazily
- adjust orchestrator and CLI for new scanner API
- update pipeline scanner integration test to compare with reference implementation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685f1ae88a4c8331b25fa95fae9083c7