### PR TITLE
Finalize CLI output

### DIFF
--- a/src/coint2/cli.py
+++ b/src/coint2/cli.py
@@ -63,7 +63,14 @@ def backtest(pair: str) -> None:
 def run_pipeline_cmd() -> None:
     """Run full pipeline of scanning and backtesting."""
 
-    run_full_pipeline()
+    results = run_full_pipeline()
+    for entry in results:
+        pair = entry.get("pair")
+        if pair:
+            click.echo(f"{pair[0]},{pair[1]}")
+        for key, value in entry.items():
+            if key != "pair":
+                click.echo(f"  {key}: {value}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- print backtest metrics for `run-pipeline` CLI command

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f1d7334008331b0e0ef296d536ec9