### PR TITLE
Add commission and slippage config options

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -9,6 +9,8 @@ backtest:
   rolling_window: 30
   zscore_threshold: 1.5
   fill_limit_pct: 0.2
+  commission_pct: 0.001  # Новая строка: Комиссия 0.1%
+  slippage_pct: 0.0005 # Новая строка: Проскальзывание 0.05%
 walk_forward:
   start_date: "2021-01-01"
   end_date: "2021-12-31"

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -21,6 +21,8 @@ class BacktestConfig(BaseModel):
     rolling_window: int
     zscore_threshold: float
     fill_limit_pct: float
+    commission_pct: float  # Новое поле
+    slippage_pct: float  # Новое поле
 
 
 class WalkForwardConfig(BaseModel):

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from pathlib import Path
 
-import numpy as np
 
 from coint2.core.data_loader import DataHandler
 import coint2.pipeline.pair_scanner as pair_scanner
@@ -38,7 +37,12 @@ def test_find_cointegrated_pairs(tmp_path: Path, monkeypatch) -> None:
             lookback_days=20, coint_pvalue_threshold=0.05, ssd_top_n=1
         ),
         backtest=BacktestConfig(
-            timeframe="1d", rolling_window=1, zscore_threshold=1.0, fill_limit_pct=0.1
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.001,
+            slippage_pct=0.0005,
         ),
         walk_forward=WalkForwardConfig(
             start_date="2021-01-01",

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -70,6 +70,8 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
             rolling_window=3,
             zscore_threshold=1.0,
             fill_limit_pct=0.0,
+            commission_pct=0.001,
+            slippage_pct=0.0005,
         ),
         walk_forward=WalkForwardConfig(
             start_date="2021-01-01",

--- a/tests/utils/test_config_loading.py
+++ b/tests/utils/test_config_loading.py
@@ -10,4 +10,6 @@ def test_load_config():
     assert isinstance(cfg, AppConfig)
     assert cfg.pair_selection.lookback_days == 90
     assert cfg.backtest.rolling_window == 30
+    assert cfg.backtest.commission_pct == 0.001
+    assert cfg.backtest.slippage_pct == 0.0005
 


### PR DESCRIPTION
## Summary
- add `commission_pct` and `slippage_pct` settings to the default YAML
- support new fields in the `BacktestConfig` dataclass
- adjust tests to use the new configuration values

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src`
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f3b9663508331a6b91f4c78d65b57