### PR TITLE
Inject configuration instead of using global

### DIFF
--- a/src/coint2/cli.py
+++ b/src/coint2/cli.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import click
 
+from pathlib import Path
+
 from coint2.core.data_loader import DataHandler
 from coint2.engine.backtest_engine import PairBacktester
 from coint2.pipeline.walk_forward_orchestrator import run_walk_forward
-from coint2.utils.config import CONFIG
+from coint2.utils.config import load_config
 
 
 @click.group()
@@ -20,11 +22,9 @@ def main() -> None:
 def backtest(pair: str) -> None:
     """Quick backtest over the entire dataset (for debugging only)."""
 
-    cfg = CONFIG
+    cfg = load_config(Path("configs/main.yaml"))
     s1, s2 = [p.strip() for p in pair.split(",")]
-    handler = DataHandler(
-        cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct
-    )
+    handler = DataHandler(cfg)
 
     ddf = handler._load_full_dataset()
     if not ddf.columns:
@@ -58,10 +58,18 @@ def backtest(pair: str) -> None:
 
 
 @main.command(name="run")
-def run_cmd() -> None:
+@click.option(
+    "--config",
+    "config_path",
+    default="configs/main.yaml",
+    help="Path to the configuration YAML file.",
+    type=click.Path(exists=True),
+)
+def run_cmd(config_path: str) -> None:
     """Run walk-forward analysis pipeline."""
 
-    metrics = run_walk_forward()
+    cfg = load_config(Path(config_path))
+    metrics = run_walk_forward(cfg)
     for key, value in metrics.items():
         click.echo(f"{key}: {value}")
 

--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -3,15 +3,15 @@ import pandas as pd  # type: ignore
 from pathlib import Path
 from typing import List
 
+from coint2.utils.config import AppConfig
+
 
 class DataHandler:
     """Utility class for loading local parquet price files."""
 
-    def __init__(self, data_dir: Path, timeframe: str, fill_limit_pct: float) -> None:
-        self.data_dir = Path(data_dir)
-        # timeframe kept for metadata compatibility but no longer used in path
-        self.timeframe = timeframe
-        self.fill_limit_pct = fill_limit_pct
+    def __init__(self, cfg: AppConfig) -> None:
+        self.data_dir = Path(cfg.data_dir)
+        self.fill_limit_pct = cfg.backtest.fill_limit_pct
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self._all_data_cache: dd.DataFrame | None = None
 

--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -6,7 +6,7 @@ from dask import delayed
 from statsmodels.tsa.stattools import coint
 
 from coint2.core import math_utils
-from coint2.utils.config import CONFIG
+from coint2.utils.config import AppConfig
 
 
 def _coint_test(series1: pd.Series, series2: pd.Series) -> float:
@@ -46,11 +46,11 @@ def find_cointegrated_pairs(
     handler,
     start_date: pd.Timestamp,
     end_date: pd.Timestamp,
-    p_value_threshold: float,
+    cfg: AppConfig,
 ) -> List[Tuple[str, str, float, float, float]]:
     """Find cointegrated pairs using SSD pre-filtering."""
 
-    cfg = CONFIG
+    p_value_threshold = cfg.pair_selection.coint_pvalue_threshold
 
     normalized = handler.load_and_normalize_data(start_date, end_date)
     if normalized.empty or len(normalized.columns) < 2:

--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -10,18 +10,15 @@ from coint2.core.data_loader import DataHandler
 from coint2.engine.backtest_engine import PairBacktester
 from coint2.pipeline.pair_scanner import find_cointegrated_pairs
 from coint2.core import performance
-from coint2.utils.config import CONFIG
+from coint2.utils.config import AppConfig
 from coint2.utils.logging_utils import get_logger
 
 
-def run_walk_forward() -> Dict[str, float]:
+def run_walk_forward(cfg: AppConfig) -> Dict[str, float]:
     """Run walk-forward analysis and return aggregated performance metrics."""
     logger = get_logger("walk_forward")
-    cfg = CONFIG
 
-    handler = DataHandler(
-        cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct
-    )
+    handler = DataHandler(cfg)
 
     start_date = pd.to_datetime(cfg.walk_forward.start_date)
     end_date = pd.to_datetime(cfg.walk_forward.end_date)
@@ -47,7 +44,7 @@ def run_walk_forward() -> Dict[str, float]:
             handler,
             training_start,
             training_end,
-            cfg.pair_selection.coint_pvalue_threshold,
+            cfg,
         )
 
         logger.info(

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -61,9 +61,3 @@ def load_config(path: Path) -> AppConfig:
     with path.open("r", encoding="utf-8") as f:
         raw_cfg = yaml.safe_load(f)
     return AppConfig(**raw_cfg)
-
-
-CONFIG = load_config(
-    Path(__file__).resolve().parents[3] / "configs" / "main.yaml"
-)
-"""Singleton configuration loaded at import time."""

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -2,6 +2,12 @@ import pandas as pd
 from pathlib import Path
 
 from coint2.core.data_loader import DataHandler
+from coint2.utils.config import (
+    AppConfig,
+    BacktestConfig,
+    PairSelectionConfig,
+    WalkForwardConfig,
+)
 
 
 def create_dataset(tmp_path: Path) -> None:
@@ -16,7 +22,31 @@ def create_dataset(tmp_path: Path) -> None:
 
 def test_load_all_data_for_period(tmp_path: Path) -> None:
     create_dataset(tmp_path)
-    handler = DataHandler(tmp_path, "1d", fill_limit_pct=0.1)
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-02",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    handler = DataHandler(cfg)
 
     result = handler.load_all_data_for_period(lookback_days=2)
 
@@ -34,7 +64,31 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
 
 def test_load_pair_data(tmp_path: Path) -> None:
     create_dataset(tmp_path)
-    handler = DataHandler(tmp_path, "1d", fill_limit_pct=0.1)
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-02",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    handler = DataHandler(cfg)
 
     result = handler.load_pair_data(
         "AAA",
@@ -58,7 +112,31 @@ def test_load_pair_data(tmp_path: Path) -> None:
 
 def test_load_and_normalize_data(tmp_path: Path) -> None:
     create_dataset(tmp_path)
-    handler = DataHandler(tmp_path, "1d", fill_limit_pct=0.1)
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-02",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    handler = DataHandler(cfg)
 
     start = pd.Timestamp("2021-01-01")
     end = pd.Timestamp("2021-01-05")

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -87,11 +87,9 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
         ),
     )
 
-    monkeypatch.setattr(wf, "CONFIG", cfg)
-
     calls = []
 
-    def fake_find_pairs(handler, start, end, thr):
+    def fake_find_pairs(handler, start, end, cfg_arg):
         calls.append((pd.Timestamp(start), pd.Timestamp(end)))
         df = handler.load_pair_data("A", "B", start, end)
         beta = df["A"].cov(df["B"]) / df["B"].var()
@@ -102,12 +100,9 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
 
     monkeypatch.setattr(wf, "find_cointegrated_pairs", fake_find_pairs)
 
-    metrics = wf.run_walk_forward()
+    metrics = wf.run_walk_forward(cfg)
 
-    expected_metrics = manual_walk_forward(
-        DataHandler(cfg.data_dir, cfg.backtest.timeframe, cfg.backtest.fill_limit_pct),
-        cfg,
-    )
+    expected_metrics = manual_walk_forward(DataHandler(cfg), cfg)
 
     assert metrics == expected_metrics
     assert len(calls) == 4


### PR DESCRIPTION
## Summary
- remove global `CONFIG` object
- load configuration in CLI and pass through function arguments
- update `DataHandler` and pipelines to accept config objects
- adjust tests for new interfaces

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f438dc34c83318e6ad1c96877d3f6