### PR TITLE
Fix walk-forward and config validation

### DIFF
--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -74,7 +74,7 @@ def run_walk_forward(cfg: AppConfig) -> Dict[str, float]:
 
         aggregated_pnl = pd.concat([aggregated_pnl, step_pnl])
 
-        current_date = testing_start
+        current_date = testing_end
 
     aggregated_pnl = aggregated_pnl.dropna()
     if aggregated_pnl.empty:

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 import yaml  # type: ignore
-from pydantic import BaseModel, DirectoryPath  # type: ignore
+from pydantic import BaseModel, DirectoryPath, Field  # type: ignore
 
 
 class PairSelectionConfig(BaseModel):
@@ -20,7 +20,7 @@ class BacktestConfig(BaseModel):
     timeframe: str
     rolling_window: int
     zscore_threshold: float
-    fill_limit_pct: float
+    fill_limit_pct: float = Field(..., gt=0.0, lt=1.0)
     commission_pct: float  # Новое поле
     slippage_pct: float  # Новое поле
     annualizing_factor: int  # Новое поле

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -48,7 +48,7 @@ def manual_walk_forward(handler: DataHandler, cfg: AppConfig) -> dict:
         )
         bt.run()
         overall = pd.concat([overall, bt.get_results()["pnl"]])
-        current = test_start
+        current = test_end
     overall = overall.dropna()
     if overall.empty:
         return {"sharpe_ratio": 0.0, "max_drawdown": 0.0, "total_pnl": 0.0}
@@ -105,4 +105,4 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
     expected_metrics = manual_walk_forward(DataHandler(cfg), cfg)
 
     assert metrics == expected_metrics
-    assert len(calls) == 4
+    assert len(calls) == 2

--- a/tests/utils/test_config_loading.py
+++ b/tests/utils/test_config_loading.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
 from coint2.utils.config import AppConfig, load_config
+from coint2.utils.config import BacktestConfig
+from pydantic import ValidationError
+import pytest
 
 
 def test_load_config():
@@ -13,4 +16,18 @@ def test_load_config():
     assert cfg.backtest.commission_pct == 0.001
     assert cfg.backtest.slippage_pct == 0.0005
     assert cfg.backtest.annualizing_factor == 365
+
+
+def test_fill_limit_pct_validation() -> None:
+    """fill_limit_pct should be between 0 and 1."""
+    with pytest.raises(ValidationError):
+        BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            fill_limit_pct=1.5,
+            commission_pct=0.001,
+            slippage_pct=0.0005,
+            annualizing_factor=365,
+        )
 


### PR DESCRIPTION
## Summary
- shift window correctly in walk forward orchestrator
- validate `fill_limit_pct` is between 0 and 1 in config
- update walk forward tests for new behaviour
- add test validating `fill_limit_pct` range

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f498f813c833197550f8d4815e227