### PR TITLE
Add portfolio and stop loss configs

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -1,5 +1,9 @@
 data_dir: "data_optimized"
 results_dir: "results"
+portfolio:
+  initial_capital: 10000.0
+  risk_per_trade_pct: 0.01  # Риск 1% на сделку
+  max_active_positions: 5   # Торгуем не более 5 пар одновременно
 pair_selection:
   lookback_days: 90
   coint_pvalue_threshold: 0.05
@@ -8,6 +12,7 @@ backtest:
   timeframe: "1d"
   rolling_window: 30
   zscore_threshold: 1.5
+  stop_loss_multiplier: 3.0 # Стоп-лосс на уровне 3-х стандартных отклонений
   fill_limit_pct: 0.2
   commission_pct: 0.001  # Новая строка: Комиссия 0.1%
   slippage_pct: 0.0005 # Новая строка: Проскальзывание 0.05%

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -14,12 +14,21 @@ class PairSelectionConfig(BaseModel):
     ssd_top_n: int
 
 
+class PortfolioConfig(BaseModel):
+    """Configuration for portfolio and risk management."""
+
+    initial_capital: float
+    risk_per_trade_pct: float
+    max_active_positions: int
+
+
 class BacktestConfig(BaseModel):
     """Configuration for backtesting parameters."""
 
     timeframe: str
     rolling_window: int
     zscore_threshold: float
+    stop_loss_multiplier: float
     fill_limit_pct: float = Field(..., gt=0.0, lt=1.0)
     commission_pct: float  # Новое поле
     slippage_pct: float  # Новое поле
@@ -40,6 +49,7 @@ class AppConfig(BaseModel):
 
     data_dir: DirectoryPath
     results_dir: Path
+    portfolio: PortfolioConfig
     pair_selection: PairSelectionConfig
     backtest: BacktestConfig
     walk_forward: WalkForwardConfig

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -5,6 +5,7 @@ from coint2.core.data_loader import DataHandler
 from coint2.utils.config import (
     AppConfig,
     BacktestConfig,
+    PortfolioConfig,
     PairSelectionConfig,
     WalkForwardConfig,
 )
@@ -25,6 +26,11 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=1,
             coint_pvalue_threshold=0.05,
@@ -34,6 +40,7 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.1,
             commission_pct=0.0,
             slippage_pct=0.0,
@@ -67,6 +74,11 @@ def test_load_pair_data(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=1,
             coint_pvalue_threshold=0.05,
@@ -76,6 +88,7 @@ def test_load_pair_data(tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.1,
             commission_pct=0.0,
             slippage_pct=0.0,
@@ -115,6 +128,11 @@ def test_load_and_normalize_data(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=1,
             coint_pvalue_threshold=0.05,
@@ -124,6 +142,7 @@ def test_load_and_normalize_data(tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.1,
             commission_pct=0.0,
             slippage_pct=0.0,
@@ -168,6 +187,11 @@ def test_clear_cache(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=1,
             coint_pvalue_threshold=0.05,
@@ -177,6 +201,7 @@ def test_clear_cache(tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.1,
             commission_pct=0.0,
             slippage_pct=0.0,

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -8,6 +8,7 @@ from coint2.utils.config import (
     AppConfig,
     PairSelectionConfig,
     BacktestConfig,
+    PortfolioConfig,
     WalkForwardConfig,
 )
 
@@ -30,6 +31,11 @@ def test_find_cointegrated_pairs(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=20, coint_pvalue_threshold=0.05, ssd_top_n=1
         ),
@@ -37,6 +43,7 @@ def test_find_cointegrated_pairs(tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.1,
             commission_pct=0.001,
             slippage_pct=0.0005,

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -4,7 +4,13 @@ from pathlib import Path
 from coint2.core.data_loader import DataHandler
 from coint2.engine.backtest_engine import PairBacktester
 from coint2.pipeline import walk_forward_orchestrator as wf
-from coint2.utils.config import AppConfig, PairSelectionConfig, BacktestConfig, WalkForwardConfig
+from coint2.utils.config import (
+    AppConfig,
+    PairSelectionConfig,
+    BacktestConfig,
+    WalkForwardConfig,
+    PortfolioConfig,
+)
 from coint2.core import performance
 
 
@@ -67,6 +73,11 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path / "results",
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
         pair_selection=PairSelectionConfig(
             lookback_days=5, coint_pvalue_threshold=0.05, ssd_top_n=1
         ),
@@ -74,6 +85,7 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
             timeframe="1d",
             rolling_window=3,
             zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
             fill_limit_pct=0.0,
             commission_pct=0.001,
             slippage_pct=0.0005,

--- a/tests/utils/test_config_loading.py
+++ b/tests/utils/test_config_loading.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from coint2.utils.config import AppConfig, load_config
-from coint2.utils.config import BacktestConfig
+from coint2.utils.config import BacktestConfig, PortfolioConfig
 from pydantic import ValidationError
 import pytest
 
@@ -13,9 +13,13 @@ def test_load_config():
     assert isinstance(cfg, AppConfig)
     assert cfg.pair_selection.lookback_days == 90
     assert cfg.backtest.rolling_window == 30
+    assert cfg.backtest.stop_loss_multiplier == 3.0
     assert cfg.backtest.commission_pct == 0.001
     assert cfg.backtest.slippage_pct == 0.0005
     assert cfg.backtest.annualizing_factor == 365
+    assert cfg.portfolio.initial_capital == 10000.0
+    assert cfg.portfolio.risk_per_trade_pct == 0.01
+    assert cfg.portfolio.max_active_positions == 5
 
 
 def test_fill_limit_pct_validation() -> None:
@@ -25,6 +29,7 @@ def test_fill_limit_pct_validation() -> None:
             timeframe="1d",
             rolling_window=1,
             zscore_threshold=1.0,
+            stop_loss_multiplier=2.0,
             fill_limit_pct=1.5,
             commission_pct=0.001,
             slippage_pct=0.0005,


### PR DESCRIPTION
## Summary
- extend `configs/main.yaml` with `portfolio` section and `stop_loss_multiplier`
- handle new options in `config.py`
- adjust tests for the updated configuration models

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f4e9f452c83318244e2755ecf17c1