### PR TITLE
Add tradability config parameters

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -7,7 +7,10 @@ portfolio:
 pair_selection:
   lookback_days: 90
   coint_pvalue_threshold: 0.05
-  ssd_top_n: 100
+  ssd_top_n: 10000
+  min_half_life_days: 1    # Минимальный период полураспада в днях
+  max_half_life_days: 30   # Максимальный период полураспада в днях
+  min_mean_crossings: 12   # Не менее 12 пересечений среднего за период калибровки
 backtest:
   timeframe: "1d"
   rolling_window: 30

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -12,6 +12,9 @@ class PairSelectionConfig(BaseModel):
     lookback_days: int
     coint_pvalue_threshold: float
     ssd_top_n: int
+    min_half_life_days: int
+    max_half_life_days: int
+    min_mean_crossings: int
 
 
 class PortfolioConfig(BaseModel):

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -35,6 +35,9 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
             lookback_days=1,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",
@@ -83,6 +86,9 @@ def test_load_pair_data(tmp_path: Path) -> None:
             lookback_days=1,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",
@@ -137,6 +143,9 @@ def test_load_and_normalize_data(tmp_path: Path) -> None:
             lookback_days=1,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",
@@ -196,6 +205,9 @@ def test_clear_cache(tmp_path: Path) -> None:
             lookback_days=1,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -37,7 +37,12 @@ def test_find_cointegrated_pairs(tmp_path: Path) -> None:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=20, coint_pvalue_threshold=0.05, ssd_top_n=1
+            lookback_days=20,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -28,7 +28,7 @@ def create_dataset(base_dir: Path) -> None:
         df.to_parquet(part_dir / "data.parquet")
 
 
-def manual_walk_forward(handler: DataHandler, cfg: AppConfigWithPortfolio) -> dict:
+def manual_walk_forward(handler: DataHandler, cfg: AppConfig) -> dict:
     overall = pd.Series(dtype=float)
     equity = cfg.portfolio.initial_capital
     current = pd.Timestamp(cfg.walk_forward.start_date)
@@ -93,7 +93,7 @@ def manual_walk_forward(handler: DataHandler, cfg: AppConfigWithPortfolio) -> di
 
 def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
     create_dataset(tmp_path)
-    cfg = AppConfigWithPortfolio(
+    cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path / "results",
         portfolio=PortfolioConfig(
@@ -102,7 +102,12 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=5, coint_pvalue_threshold=0.05, ssd_top_n=1
+            lookback_days=5,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
         ),
         backtest=BacktestConfig(
             timeframe="1d",
@@ -119,11 +124,6 @@ def test_walk_forward(monkeypatch, tmp_path: Path) -> None:
             end_date="2021-01-11",
             training_period_days=2,
             testing_period_days=2,
-        ),
-        portfolio=PortfolioConfig(
-            initial_capital=1000.0,
-            risk_per_trade_pct=0.1,
-            max_active_positions=1,
         ),
     )
 

--- a/tests/utils/test_config_loading.py
+++ b/tests/utils/test_config_loading.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from coint2.utils.config import AppConfig, load_config
-from coint2.utils.config import BacktestConfig, PortfolioConfig
+from coint2.utils.config import BacktestConfig
 from pydantic import ValidationError
 import pytest
 
@@ -12,6 +12,10 @@ def test_load_config():
     cfg = load_config(root / "configs" / "main.yaml")
     assert isinstance(cfg, AppConfig)
     assert cfg.pair_selection.lookback_days == 90
+    assert cfg.pair_selection.ssd_top_n == 10000
+    assert cfg.pair_selection.min_half_life_days == 1
+    assert cfg.pair_selection.max_half_life_days == 30
+    assert cfg.pair_selection.min_mean_crossings == 12
     assert cfg.backtest.rolling_window == 30
     assert cfg.backtest.stop_loss_multiplier == 3.0
     assert cfg.backtest.commission_pct == 0.001


### PR DESCRIPTION
## Summary
- expand `pair_selection` config with tradability filters
- load new fields in `PairSelectionConfig`
- update tests for new config parameters

## Testing
- `ruff check src tests`
- `mypy src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f53f27d508331862764955f76a368