### PR TITLE
Add tradability filter to pair scanner

### DIFF
--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -9,6 +9,38 @@ from coint2.core import math_utils
 from coint2.utils.config import AppConfig
 
 
+@delayed
+def _test_pair_for_tradability(
+    handler,
+    symbol1: str,
+    symbol2: str,
+    start_date: pd.Timestamp,
+    end_date: pd.Timestamp,
+    min_half_life: float,
+    max_half_life: float,
+    min_crossings: int,
+) -> Tuple[str, str] | None:
+    """Lazy tradability filter for a pair."""
+    pair_data = handler.load_pair_data(symbol1, symbol2, start_date, end_date)
+    if pair_data.empty or len(pair_data.columns) < 2:
+        return None
+
+    y = pair_data[symbol1]
+    x = pair_data[symbol2]
+    beta = y.cov(x) / x.var()
+    spread = y - beta * x
+
+    half_life = math_utils.calculate_half_life(spread)
+    if half_life < min_half_life or half_life > max_half_life:
+        return None
+
+    crossings = math_utils.count_mean_crossings(spread)
+    if crossings < min_crossings:
+        return None
+
+    return symbol1, symbol2
+
+
 def _coint_test(series1: pd.Series, series2: pd.Series) -> float:
     """Run cointegration test and return p-value."""
     _score, pvalue, _ = coint(series1, series2)
@@ -52,6 +84,7 @@ def find_cointegrated_pairs(
 
     p_value_threshold = cfg.pair_selection.coint_pvalue_threshold
 
+    # Stage 1: SSD pre-filter
     normalized = handler.load_and_normalize_data(start_date, end_date)
     if normalized.empty or len(normalized.columns) < 2:
         return []
@@ -59,8 +92,27 @@ def find_cointegrated_pairs(
     ssd = math_utils.calculate_ssd(normalized)
     top_pairs = ssd.head(cfg.pair_selection.ssd_top_n).index.tolist()
 
-    lazy_results = []
+    # Stage 2: tradability filter
+    lazy_tradable = []
     for s1, s2 in top_pairs:
+        task = _test_pair_for_tradability(
+            handler,
+            s1,
+            s2,
+            start_date,
+            end_date,
+            cfg.pair_selection.min_half_life_days,
+            cfg.pair_selection.max_half_life_days,
+            cfg.pair_selection.min_mean_crossings,
+        )
+        lazy_tradable.append(task)
+
+    tradable_results = dask.compute(*lazy_tradable, scheduler="processes")
+    tradable_pairs = [p for p in tradable_results if p is not None]
+
+    # Stage 3: cointegration filter
+    lazy_results = []
+    for s1, s2 in tradable_pairs:
         task = _test_pair_for_coint(
             handler,
             s1,


### PR DESCRIPTION
## Summary
- integrate new tradability check into the pair scanner
- add `_test_pair_for_tradability` helper
- update integration test to verify call to tradability filter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685f567f0914833199925ea3ffbe29df