### PR TITLE
Add numba-optimized half-life and mean crossings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ pyyaml = "*"
 numpy = "*"
 pandas = "*"
 scipy = "*"
+numba = "*"
 # ↓↓↓ ЭТИ ЗАВИСИМОСТИ МЫ БЕРЕМ ИЗ ВЕТКИ CODEX ↓↓↓
 pyarrow = "*"
 statsmodels = "*"

--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -30,11 +30,12 @@ def _test_pair_for_tradability(
     beta = y.cov(x) / x.var()
     spread = y - beta * x
 
-    half_life = math_utils.calculate_half_life(spread)
+    spread_np = spread.to_numpy()
+    half_life = math_utils.half_life_numba(spread_np)
     if half_life < min_half_life or half_life > max_half_life:
         return None
 
-    crossings = math_utils.count_mean_crossings(spread)
+    crossings = math_utils.mean_crossings_numba(spread_np)
     if crossings < min_crossings:
         return None
 

--- a/tests/core/test_math_utils.py
+++ b/tests/core/test_math_utils.py
@@ -8,6 +8,8 @@ from coint2.core.math_utils import (
     calculate_ssd,
     calculate_half_life,
     count_mean_crossings,
+    half_life_numba,
+    mean_crossings_numba,
 )
 
 
@@ -73,3 +75,15 @@ def test_calculate_half_life_deterministic() -> None:
 def test_count_mean_crossings() -> None:
     series = pd.Series([1, -1, 1, -1, 1, -1])
     assert count_mean_crossings(series) == 5
+
+
+def test_half_life_numba():
+    series = np.array([10.0, 9.0, 8.0, 7.0, 6.0, 5.0])
+    result = half_life_numba(series)
+    assert np.isclose(result, 1.0)
+
+
+def test_mean_crossings_numba():
+    series = np.array([1, 2, 1, 0, -1, -2, -1, 0, 1])
+    result = mean_crossings_numba(series)
+    assert result == 2


### PR DESCRIPTION
## Summary
- add numba dependency
- add numba-compiled half-life and mean crossings
- use optimized functions in pair scanner
- test the new optimized utilities

## Testing
- `poetry lock` *(fails: The lock file does not have a metadata entry)*
- `poetry install` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f5c6b4e388331a2b37ac23d2558e2