### PR TITLE
Memory efficient SSD computation

### DIFF
--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -90,8 +90,11 @@ def find_cointegrated_pairs(
     if normalized.empty or len(normalized.columns) < 2:
         return []
 
-    ssd = math_utils.calculate_ssd(normalized)
-    top_pairs = ssd.head(cfg.pair_selection.ssd_top_n).index.tolist()
+    ssd = math_utils.calculate_ssd(
+        normalized,
+        top_k=cfg.pair_selection.ssd_top_n,
+    )
+    top_pairs = ssd.index.tolist()
 
     # Stage 2: tradability filter
     lazy_tradable = []


### PR DESCRIPTION
## Summary
- implement block-based `calculate_ssd` to reduce memory usage
- pass `ssd_top_n` to `calculate_ssd` in the pair scanner
- update unit test for SSD computation with block support

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_685f5e7163ec833193c83554b6f9f8ef