### PR TITLE
Fix pyarrow partition column conflict

### DIFF
--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -40,7 +40,12 @@ class DataHandler:
             self._all_data_cache = dd.from_pandas(pd.DataFrame(), npartitions=1)
             return self._all_data_cache
 
-        ddf = dd.read_parquet(self.data_dir, engine="pyarrow")
+        # FIX: Specify columns explicitly to avoid conflicts with partition
+        # columns when using the pyarrow engine. Dask will create the
+        # 'symbol' column from the directory structure automatically.
+        ddf = dd.read_parquet(
+            self.data_dir, engine="pyarrow", columns=["timestamp", "close"]
+        )
 
         self._all_data_cache = ddf
         return ddf
@@ -154,7 +159,11 @@ class DataHandler:
         if not self.data_dir.exists():
             return pd.DataFrame()
 
-        ddf = dd.read_parquet(self.data_dir, engine="pyarrow")
+        # FIX: Specify columns explicitly to avoid the same partition column
+        # conflict as in _load_full_dataset.
+        ddf = dd.read_parquet(
+            self.data_dir, engine="pyarrow", columns=["timestamp", "close"]
+        )
         if not ddf.columns:
             return pd.DataFrame()
 


### PR DESCRIPTION
## Summary
- specify columns on `dd.read_parquet` calls to avoid pyarrow partition column conflicts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685fbcc5645c8331941a431195998522