### PR TITLE
Add empty_ddf utility

### DIFF
--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -7,6 +7,7 @@ import numpy as np
 import logging
 
 from coint2.utils.config import AppConfig
+from coint2.utils import empty_ddf
 
 # Настройка логгера
 logger = logging.getLogger(__name__)
@@ -48,7 +49,7 @@ class DataHandler:
             return self._all_data_cache
 
         if not self.data_dir.exists():
-            self._all_data_cache = dd.from_pandas(pd.DataFrame(), npartitions=1)
+            self._all_data_cache = empty_ddf()
             return self._all_data_cache
 
         try:
@@ -79,7 +80,7 @@ class DataHandler:
                 parquet_files = glob.glob(str(self.data_dir) + "/**/data.parquet", recursive=True)
                 if not parquet_files:
                     print(f"Не найдено ни одного parquet файла в {self.data_dir}")
-                    return dd.DataFrame()
+                    return empty_ddf()
                 
                 print(f"Найдено {len(parquet_files)} файлов parquet")
                 
@@ -174,7 +175,7 @@ class DataHandler:
                     
                 if not dfs:
                     print("Не удалось загрузить ни один файл")
-                    return dd.from_pandas(pd.DataFrame(), npartitions=1)
+                    return empty_ddf()
                     
                 try:
                     # Объединяем все Dask DataFrame в один
@@ -183,12 +184,12 @@ class DataHandler:
                     return combined_ddf
                 except Exception as concat_error:
                     print(f"Ошибка при объединении DataFrame: {str(concat_error)}")
-                    return dd.from_pandas(pd.DataFrame(), npartitions=1)
+                    return empty_ddf()
                     
             except Exception as e2:
                 print(f"Ошибка при использовании запасного варианта: {str(e2)}")
                 # Если и запасной вариант не сработал, возвращаем пустой фрейм
-                return dd.from_pandas(pd.DataFrame(), npartitions=1)
+                return empty_ddf()
 
     def load_all_data_for_period(self, lookback_days: int) -> pd.DataFrame:
         """Load close prices for all symbols for the given lookback period."""

--- a/src/coint2/utils/__init__.py
+++ b/src/coint2/utils/__init__.py
@@ -1,1 +1,3 @@
 """Utility subpackage for coint2."""
+
+from .dask_utils import empty_ddf

--- a/src/coint2/utils/dask_utils.py
+++ b/src/coint2/utils/dask_utils.py
@@ -1,0 +1,7 @@
+import pandas as pd
+import dask.dataframe as dd
+
+
+def empty_ddf() -> dd.DataFrame:
+    """Return an empty Dask DataFrame."""
+    return dd.from_pandas(pd.DataFrame(), npartitions=1)

--- a/tests/core/test_empty_df.py
+++ b/tests/core/test_empty_df.py
@@ -1,0 +1,9 @@
+import dask.dataframe as dd
+
+from coint2.utils import empty_ddf
+
+
+def test_empty_ddf_returns_empty_dataframe() -> None:
+    ddf = empty_ddf()
+    assert isinstance(ddf, dd.DataFrame)
+    assert ddf.compute().empty


### PR DESCRIPTION
## Summary
- fix invalid `dd.DataFrame()` call by using `empty_ddf`
- expose `empty_ddf` from utils
- unit test for helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ffe95ad5c8331a3dad159b813944e