### PR TITLE
Expand file discovery glob

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -25,3 +25,5 @@ walk_forward:
   end_date: "2022-12-31"
   training_period_days: 60
   testing_period_days: 30
+max_shards: null
+  

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -31,6 +31,7 @@ backtest:
   rolling_window: 30
   zscore_threshold: 1.5
   fill_limit_pct: 0.2
+max_shards: null
 ```
 
 ## 3. Run the project

--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -18,6 +18,7 @@ class DataHandler:
     def __init__(self, cfg: AppConfig) -> None:
         self.data_dir = Path(cfg.data_dir)
         self.fill_limit_pct = cfg.backtest.fill_limit_pct
+        self.max_shards = cfg.max_shards
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self._all_data_cache: dd.DataFrame | None = None
 
@@ -68,20 +69,19 @@ class DataHandler:
             print(f"Ошибка загрузки данных через Dask в _load_full_dataset: {str(e)}")
             
             try:
-                # Запасной вариант: использование glob для обхода всех файлов
-                import glob
-                # Пробуем загрузить файлы вручную через pandas, если dd.read_parquet не работает
-                # Используем существующий импорт dd на уровне модуля
-                dfs = []
+                # Запасной вариант: ручной обход всех parquet-файлов
                 print("Попытка загрузки через glob-обход файлов...")
-                
-                # Собираем все файлы data.parquet рекурсивно
-                parquet_files = glob.glob(str(self.data_dir) + "/**/data.parquet", recursive=True)
+
+                # Собираем все файлы .parquet рекурсивно
+                parquet_files = [str(p) for p in Path(self.data_dir).rglob("*.parquet")]
                 if not parquet_files:
                     print(f"Не найдено ни одного parquet файла в {self.data_dir}")
                     return dd.DataFrame()
                 
                 print(f"Найдено {len(parquet_files)} файлов parquet")
+
+                if self.max_shards is not None:
+                    parquet_files = parquet_files[: self.max_shards]
                 
                 # Словарь для отслеживания проанализированных символов для диагностики
                 analyzed_symbols = set()
@@ -91,7 +91,7 @@ class DataHandler:
                 for file_path in parquet_files:
                     path = Path(file_path)
                     
-                    # Определяем symbol из пути (3 уровня вверх от файла: symbol=XXX/year=YYYY/month=MM/data.parquet)
+                    # Определяем symbol из пути (3 уровня вверх от файла: symbol=XXX/year=YYYY/month=MM/part.parquet)
                     symbol_dir = path.parent.parent.parent.name
                     symbol = symbol_dir.replace("symbol=", "")
                     
@@ -432,22 +432,21 @@ class DataHandler:
             
             try:
                 # Запасной вариант - ручной обход parquet-файлов
-                import glob
                 from pathlib import Path
-                
+
                 # Ищем все файлы .parquet рекурсивно в директории данных
-                parquet_files = glob.glob(str(self.data_dir) + "/**/data.parquet", recursive=True)
+                parquet_files = list(Path(self.data_dir).rglob("*.parquet"))
                 
                 # Создаем пустой список для хранения данных
                 dfs = []
-                
+
                 total_files = len(parquet_files)
                 print(f"Found {total_files} parquet files to process manually")
-                
-                # Ограничиваем количество файлов для быстрой загрузки
-                file_limit = min(total_files, 500)
-                
-                for file_path in parquet_files[:file_limit]:  
+
+                if self.max_shards is not None:
+                    parquet_files = parquet_files[: self.max_shards]
+
+                for file_path in parquet_files:
                     path = Path(file_path)
                     
                     # Извлекаем информацию о символе из пути

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -56,6 +56,7 @@ class AppConfig(BaseModel):
     pair_selection: PairSelectionConfig
     backtest: BacktestConfig
     walk_forward: WalkForwardConfig
+    max_shards: int | None = None
 
 
 def load_config(path: Path) -> AppConfig:

--- a/tests/core/test_file_glob.py
+++ b/tests/core/test_file_glob.py
@@ -1,0 +1,59 @@
+import pandas as pd
+from pathlib import Path
+from uuid import uuid4
+
+from coint2.core.data_loader import DataHandler
+from coint2.utils.config import (
+    AppConfig,
+    BacktestConfig,
+    PairSelectionConfig,
+    PortfolioConfig,
+    WalkForwardConfig,
+)
+
+
+def create_random_shards(base: Path) -> None:
+    idx = pd.date_range("2021-01-01", periods=3, freq="D")
+    for sym in ["AAA", "BBB"]:
+        part = base / f"symbol={sym}" / "year=2021" / "month=01"
+        part.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame({"timestamp": idx, "close": range(len(idx))})
+        df.to_parquet(part / f"{uuid4().hex}.parquet")
+
+
+def test_rglob_finds_all_files(tmp_path: Path) -> None:
+    create_random_shards(tmp_path)
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        portfolio=PortfolioConfig(initial_capital=1, risk_per_trade_pct=0.1, max_active_positions=1),
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-02",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    handler = DataHandler(cfg)
+
+    df = handler.load_all_data_for_period(lookback_days=2)
+
+    assert not df.empty


### PR DESCRIPTION
## Summary
- add `max_shards` option to config
- document the new option
- discover all `*.parquet` files when dask loading fails
- limit manual shard loading via `max_shards`
- add regression test for shard file globbing

## Testing
- `pytest -q tests/core/test_file_glob.py -k ''` *(fails: No module named 'pandas')*
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685ffea05fdc833191141901d57a9308