### PR TITLE
Fix pandas pivot with duplicates

### DIFF
--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -230,9 +230,19 @@ class DataHandler:
         if filtered_df.empty:
             return pd.DataFrame()
 
-        wide_pdf = filtered_df.pivot(
-            index="timestamp", columns="symbol", values="close"
-        )
+        if filtered_df.duplicated(subset=["timestamp", "symbol"]).any():
+            wide_pdf = filtered_df.pivot_table(
+                index="timestamp",
+                columns="symbol",
+                values="close",
+                aggfunc="last",
+            )
+        else:
+            wide_pdf = filtered_df.pivot(
+                index="timestamp",
+                columns="symbol",
+                values="close",
+            )
         if wide_pdf.empty:
             return pd.DataFrame()
 
@@ -438,9 +448,19 @@ class DataHandler:
                 print(f"No data found between {start_date} and {end_date}")
                 return pd.DataFrame()
 
-            wide_pdf = filtered_df.pivot(
-                index="timestamp", columns="symbol", values="close"
-            )
+            if filtered_df.duplicated(subset=["timestamp", "symbol"]).any():
+                wide_pdf = filtered_df.pivot_table(
+                    index="timestamp",
+                    columns="symbol",
+                    values="close",
+                    aggfunc="last",
+                )
+            else:
+                wide_pdf = filtered_df.pivot(
+                    index="timestamp",
+                    columns="symbol",
+                    values="close",
+                )
 
             if wide_pdf.empty:
                 print(f"No data found between {start_date} and {end_date}")
@@ -538,7 +558,12 @@ class DataHandler:
                 combined_df = pd.concat(dfs, ignore_index=True)
                 
                 # Преобразуем в широкий формат
-                wide_df = combined_df.pivot_table(index="timestamp", columns="symbol", values="close")
+                wide_df = combined_df.pivot_table(
+                    index="timestamp",
+                    columns="symbol",
+                    values="close",
+                    aggfunc="last",
+                )
                 wide_df = wide_df.sort_index()
 
                 self._freq = pd.infer_freq(wide_df.index)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,82 @@
+import pandas as pd
+from pathlib import Path
+
+from coint2.core.data_loader import DataHandler
+from coint2.utils.config import (
+    AppConfig,
+    BacktestConfig,
+    PortfolioConfig,
+    PairSelectionConfig,
+    WalkForwardConfig,
+)
+
+
+def create_dataset_with_duplicates(tmp_path: Path) -> None:
+    idx = pd.date_range("2021-01-01", periods=3, freq="D")
+    for sym, shift in [("AAA", 0), ("BBB", 100)]:
+        part_dir = tmp_path / f"symbol={sym}" / "year=2021" / "month=01"
+        part_dir.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame({
+            "timestamp": list(idx) + [idx[1]],  # duplicate second day
+            "close": [shift + i for i in range(3)] + [shift + 99],
+        })
+        df.to_parquet(part_dir / "data.parquet")
+
+
+def _create_handler(tmp_path: Path) -> DataHandler:
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-03",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    return DataHandler(cfg)
+
+
+def test_pivot(tmp_path: Path) -> None:
+    create_dataset_with_duplicates(tmp_path)
+    handler = _create_handler(tmp_path)
+
+    result = handler.load_all_data_for_period(lookback_days=3)
+
+    pdf = pd.read_parquet(tmp_path, engine="pyarrow")
+    pdf["timestamp"] = pd.to_datetime(pdf["timestamp"])
+    end_date = pdf["timestamp"].max()
+    start_date = end_date - pd.Timedelta(days=3)
+    filtered = pdf[pdf["timestamp"] >= start_date]
+    expected = filtered.pivot_table(
+        index="timestamp",
+        columns="symbol",
+        values="close",
+        aggfunc="last",
+    )
+    expected = expected.sort_index()
+
+    pd.testing.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- handle duplicated rows when pivoting price data
- cover duplicate pivot logic with tests

## Testing
- `pytest -k pivot -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pytest tests/test_data_loader.py::test_pivot -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686058b008d4833194dc7861c454472a