### PR TITLE
Guarantee symbol column when reading parquet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ pandas = "*"
 scipy = "*"
 numba = "*"
 # ↓↓↓ ЭТИ ЗАВИСИМОСТИ МЫ БЕРЕМ ИЗ ВЕТКИ CODEX ↓↓↓
-pyarrow = "*"
+pyarrow = ">=8.0.0"
 statsmodels = "*"
 dask = {extras = ["dataframe"], version = "*"} # Устанавливаем dask с поддержкой DataFrame
 dask-expr = "*" # Нужен для read_parquet в новых версиях

--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -64,7 +64,7 @@ class DataHandler:
             ddf = dd.read_parquet(
                 self.data_dir,
                 engine="pyarrow",
-                columns=["timestamp", "close"],
+                columns=None,  # partition columns like 'symbol' included automatically
                 ignore_metadata_file=True,  # Игнорируем _metadata файл
                 calculate_divisions=False,   # Избегаем авто-расчёта разделений
                 # В партициях используется ведущий ноль для месяцев (month=01, month=02 и т.д.)

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -252,3 +252,47 @@ def test_clear_cache(tmp_path: Path) -> None:
     pd.testing.assert_frame_equal(result, expected)
     assert "CCC" in result.columns
 
+
+def test_partition_symbol_column(tmp_path: Path) -> None:
+    create_dataset(tmp_path)
+    cfg = AppConfig(
+        data_dir=tmp_path,
+        results_dir=tmp_path,
+        portfolio=PortfolioConfig(
+            initial_capital=10000.0,
+            risk_per_trade_pct=0.01,
+            max_active_positions=5,
+        ),
+        pair_selection=PairSelectionConfig(
+            lookback_days=1,
+            coint_pvalue_threshold=0.05,
+            ssd_top_n=1,
+            min_half_life_days=1,
+            max_half_life_days=30,
+            min_mean_crossings=12,
+        ),
+        backtest=BacktestConfig(
+            timeframe="1d",
+            rolling_window=1,
+            zscore_threshold=1.0,
+            stop_loss_multiplier=3.0,
+            fill_limit_pct=0.1,
+            commission_pct=0.0,
+            slippage_pct=0.0,
+            annualizing_factor=365,
+        ),
+        walk_forward=WalkForwardConfig(
+            start_date="2021-01-01",
+            end_date="2021-01-02",
+            training_period_days=1,
+            testing_period_days=1,
+        ),
+    )
+    handler = DataHandler(cfg)
+
+    ddf = handler._load_full_dataset()
+    assert "symbol" in ddf.columns
+
+    pdf = ddf.compute()
+    assert "symbol" in pdf.columns
+


### PR DESCRIPTION
## Summary
- ensure partition column `symbol` is loaded by Dask
- require PyArrow 8 or newer
- test that `_load_full_dataset` returns the `symbol` column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686058b73000833193cac1d54408e263