### PR TITLE
Add time utils and refactor data loader

### DIFF
--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -7,7 +7,7 @@ import numpy as np
 import logging
 
 from coint2.utils.config import AppConfig
-from coint2.utils import empty_ddf
+from coint2.utils import empty_ddf, ensure_datetime_index, infer_frequency
 
 # Настройка логгера
 logger = logging.getLogger(__name__)
@@ -236,10 +236,9 @@ class DataHandler:
         if wide_pdf.empty:
             return pd.DataFrame()
 
-        # Сортируем по индексу (дате)
-        wide_pdf = wide_pdf.sort_index()
+        wide_pdf = ensure_datetime_index(wide_pdf)
 
-        self._freq = pd.infer_freq(wide_pdf.index)
+        self._freq = infer_frequency(wide_pdf.index)
         if self._freq:
             wide_pdf = wide_pdf.asfreq(self._freq)
 
@@ -311,7 +310,7 @@ class DataHandler:
             return pd.DataFrame()
 
         # Обработка пропущенных значений
-        freq = pd.infer_freq(wide_df.index)
+        freq = infer_frequency(wide_df.index)
         self._freq = freq
         if freq:
             wide_df = wide_df.asfreq(freq)
@@ -446,10 +445,9 @@ class DataHandler:
                 print(f"No data found between {start_date} and {end_date}")
                 return pd.DataFrame()
 
-            # Сортируем по индексу (датам)
-            wide_pdf = wide_pdf.sort_index()
+            wide_pdf = ensure_datetime_index(wide_pdf)
 
-            self._freq = pd.infer_freq(wide_pdf.index)
+            self._freq = infer_frequency(wide_pdf.index)
             if self._freq:
                 wide_pdf = wide_pdf.asfreq(self._freq)
 
@@ -539,9 +537,9 @@ class DataHandler:
                 
                 # Преобразуем в широкий формат
                 wide_df = combined_df.pivot_table(index="timestamp", columns="symbol", values="close")
-                wide_df = wide_df.sort_index()
+                wide_df = ensure_datetime_index(wide_df)
 
-                self._freq = pd.infer_freq(wide_df.index)
+                self._freq = infer_frequency(wide_df.index)
                 if self._freq:
                     wide_df = wide_df.asfreq(self._freq)
 

--- a/src/coint2/utils/__init__.py
+++ b/src/coint2/utils/__init__.py
@@ -1,5 +1,5 @@
 """Utility subpackage for coint2."""
 
 from .dask_utils import empty_ddf
-
-__all__ = ["empty_ddf"]
+from .time_utils import ensure_datetime_index, infer_frequency
+__all__ = ["empty_ddf", "ensure_datetime_index", "infer_frequency"]

--- a/src/coint2/utils/time_utils.py
+++ b/src/coint2/utils/time_utils.py
@@ -1,0 +1,25 @@
+import pandas as pd
+
+def ensure_datetime_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Return a copy of ``df`` with a timezone naive ``DatetimeIndex``.
+
+    The index is converted to ``DatetimeIndex`` if needed, timezone
+    information is stripped and the index is sorted.
+    """
+    result = df.copy()
+    if not isinstance(result.index, pd.DatetimeIndex):
+        result.index = pd.to_datetime(result.index)
+    if getattr(result.index, "tz", None) is not None:
+        result.index = result.index.tz_localize(None)
+    result = result.sort_index()
+    return result
+
+
+def infer_frequency(idx: pd.Index) -> str | None:
+    """Infer frequency of a ``DatetimeIndex`` safely."""
+    if not isinstance(idx, pd.DatetimeIndex):
+        idx = pd.to_datetime(idx)
+    try:
+        return pd.infer_freq(idx)
+    except (TypeError, ValueError):
+        return None

--- a/tests/utils/test_time_utils.py
+++ b/tests/utils/test_time_utils.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import pytest
+
+from coint2.utils.time_utils import ensure_datetime_index, infer_frequency
+
+
+def test_ensure_datetime_index_sorts_and_drops_tz() -> None:
+    idx = pd.date_range("2021-01-01", periods=2, freq="D", tz="UTC")[::-1]
+    df = pd.DataFrame({"a": [1, 2]}, index=idx)
+
+    result = ensure_datetime_index(df)
+
+    assert isinstance(result.index, pd.DatetimeIndex)
+    assert result.index.tz is None
+    expected = list(pd.date_range("2021-01-01", periods=2, freq="D"))
+    assert list(result.index) == expected
+
+
+@pytest.mark.parametrize("freq", ["D", "H", "15T"])
+def test_infer_frequency_regular(freq: str) -> None:
+    idx = pd.date_range("2021-01-01", periods=5, freq=freq)
+    assert infer_frequency(idx) == freq
+
+
+def test_infer_frequency_irregular() -> None:
+    idx = pd.to_datetime(["2021-01-01", "2021-01-02", "2021-01-04"])
+    assert infer_frequency(idx) is None
+


### PR DESCRIPTION
## Summary
- add `ensure_datetime_index` and `infer_frequency` to new `time_utils`
- expose new helpers via utils package
- refactor `DataHandler` to reuse these helpers
- add unit tests for the new time utilities

## Testing
- `pip install pandas` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*


------
https://chatgpt.com/codex/tasks/task_e_686058e4945c83319606b16479ebcb50