### PR TITLE
Fix lookback usage in DataHandler

### DIFF
--- a/src/coint2/core/data_loader.py
+++ b/src/coint2/core/data_loader.py
@@ -38,6 +38,7 @@ class DataHandler:
         self._all_data_cache: dd.DataFrame | None = None
         self._freq: str | None = None
         self._lock = threading.Lock()
+        self.lookback_days: int = cfg.pair_selection.lookback_days
 
     @property
     def freq(self) -> str | None:
@@ -119,8 +120,9 @@ class DataHandler:
                     self._all_data_cache = empty_ddf()
                 return self._all_data_cache
 
-    def load_all_data_for_period(self, lookback_days: int) -> pd.DataFrame:
-        """Load close prices for all symbols for the given lookback period."""
+    def load_all_data_for_period(self) -> pd.DataFrame:
+        """Load close prices for all symbols for the configured lookback period."""
+
         ddf = self._load_full_dataset()
 
         # Проверка на пустой DataFrame
@@ -136,7 +138,7 @@ class DataHandler:
             return pd.DataFrame()
 
         # Вычисляем начальную дату для фильтрации
-        start_date = end_date - pd.Timedelta(days=lookback_days)
+        start_date = end_date - pd.Timedelta(days=self.lookback_days)
         
         # Фильтруем по дате
         filtered_ddf = ddf[ddf["timestamp"] >= start_date]

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -33,7 +33,7 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=1,
+            lookback_days=2,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
             min_half_life_days=1,
@@ -59,7 +59,7 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
     )
     handler = DataHandler(cfg)
 
-    result = handler.load_all_data_for_period(lookback_days=2)
+    result = handler.load_all_data_for_period()
 
     pdf = pd.read_parquet(tmp_path, engine="pyarrow")
     pdf["timestamp"] = pd.to_datetime(pdf["timestamp"])
@@ -84,7 +84,7 @@ def test_load_pair_data(tmp_path: Path) -> None:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=1,
+            lookback_days=10,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
             min_half_life_days=1,
@@ -141,7 +141,7 @@ def test_load_and_normalize_data(tmp_path: Path) -> None:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=1,
+            lookback_days=10,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
             min_half_life_days=1,
@@ -229,7 +229,7 @@ def test_clear_cache(tmp_path: Path) -> None:
     )
     handler = DataHandler(cfg)
 
-    initial = handler.load_all_data_for_period(lookback_days=10)
+    initial = handler.load_all_data_for_period()
     assert "CCC" not in initial.columns
 
     idx = pd.date_range("2021-01-01", periods=5, freq="D")
@@ -239,7 +239,7 @@ def test_clear_cache(tmp_path: Path) -> None:
     df.to_parquet(part_dir / "data.parquet")
 
     handler.clear_cache()
-    result = handler.load_all_data_for_period(lookback_days=10)
+    result = handler.load_all_data_for_period()
 
     pdf = pd.read_parquet(tmp_path, engine="pyarrow")
     pdf["timestamp"] = pd.to_datetime(pdf["timestamp"])

--- a/tests/core/test_file_glob.py
+++ b/tests/core/test_file_glob.py
@@ -28,7 +28,7 @@ def test_rglob_finds_all_files(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(initial_capital=1, risk_per_trade_pct=0.1, max_active_positions=1),
         pair_selection=PairSelectionConfig(
-            lookback_days=1,
+            lookback_days=2,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
             min_half_life_days=1,
@@ -54,6 +54,6 @@ def test_rglob_finds_all_files(tmp_path: Path) -> None:
     )
     handler = DataHandler(cfg)
 
-    df = handler.load_all_data_for_period(lookback_days=2)
+    df = handler.load_all_data_for_period()
 
     assert not df.empty

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -63,7 +63,7 @@ def test_find_cointegrated_pairs(monkeypatch, tmp_path: Path) -> None:
         ),
     )
     handler = DataHandler(cfg)
-    data = handler.load_all_data_for_period(lookback_days=20)
+    data = handler.load_all_data_for_period()
 
     trad_calls: list[tuple[str, str]] = []
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -23,7 +23,7 @@ def create_dataset_with_duplicates(tmp_path: Path) -> None:
         df.to_parquet(part_dir / "data.parquet")
 
 
-def _create_handler(tmp_path: Path) -> DataHandler:
+def _create_handler(tmp_path: Path, lookback_days: int = 1) -> DataHandler:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
@@ -33,7 +33,7 @@ def _create_handler(tmp_path: Path) -> DataHandler:
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
-            lookback_days=1,
+            lookback_days=lookback_days,
             coint_pvalue_threshold=0.05,
             ssd_top_n=1,
             min_half_life_days=1,
@@ -62,9 +62,9 @@ def _create_handler(tmp_path: Path) -> DataHandler:
 
 def test_pivot(tmp_path: Path) -> None:
     create_dataset_with_duplicates(tmp_path)
-    handler = _create_handler(tmp_path)
+    handler = _create_handler(tmp_path, lookback_days=3)
 
-    result = handler.load_all_data_for_period(lookback_days=3)
+    result = handler.load_all_data_for_period()
 
     pdf = pd.read_parquet(tmp_path, engine="pyarrow")
     pdf["timestamp"] = pd.to_datetime(pdf["timestamp"])


### PR DESCRIPTION
## Summary
- store default `lookback_days` in `DataHandler`
- use configured lookback period in `load_all_data_for_period`
- adjust tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68610925a4b48331a42a0b6e36f43734