### PR TITLE
Fix cointegration test data alignment

### DIFF
--- a/src/coint2/pipeline/pair_scanner.py
+++ b/src/coint2/pipeline/pair_scanner.py
@@ -118,7 +118,9 @@ def _test_pair_for_coint(
         logger.debug(f"Пара {symbol1}-{symbol2}: слишком много NaN ({nan_ratio1:.2f}, {nan_ratio2:.2f})")
         return None
     
-    pvalue = _coint_test(pair_data[symbol1].dropna(), pair_data[symbol2].dropna())
+    # Очищаем данные от NaN одновременно по обоим столбцам, чтобы сохранить синхронизацию
+    clean_data = pair_data[[symbol1, symbol2]].dropna()
+    pvalue = _coint_test(clean_data[symbol1], clean_data[symbol2])
     logger.debug(f"Пара {symbol1}-{symbol2}: p-value = {pvalue:.4f} (требуется < {p_value_threshold:.4f})")
     
     if pvalue >= p_value_threshold:


### PR DESCRIPTION
## Summary
- ensure cointegration test uses aligned series

## Testing
- `ruff check src/coint2/pipeline/pair_scanner.py`
- `mypy src/coint2/pipeline/pair_scanner.py`
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861100282e883319b04e0048eef1f67