### PR TITLE
Adjust risk allocation per pair

### DIFF
--- a/configs/main.yaml
+++ b/configs/main.yaml
@@ -2,7 +2,7 @@ data_dir: "data_optimized"
 results_dir: "results"
 portfolio:
   initial_capital: 10000.0
-  risk_per_trade_pct: 0.01  # Риск 1% на сделку
+  risk_per_position_pct: 0.01  # Риск 1% на сделку
   max_active_positions: 5   # Торгуем не более 5 пар одновременно
 pair_selection:
   lookback_days: 90

--- a/src/coint2/pipeline/walk_forward_orchestrator.py
+++ b/src/coint2/pipeline/walk_forward_orchestrator.py
@@ -77,13 +77,11 @@ def run_walk_forward(cfg: AppConfig) -> dict[str, float]:
         sorted_pairs = sorted(pairs)
         active_pairs = sorted_pairs[: cfg.portfolio.max_active_positions]
 
-        total_risk_capital = equity * cfg.portfolio.risk_per_trade_pct
-
         step_pnl = pd.Series(dtype=float)
         total_step_pnl = 0.0
 
         if active_pairs:
-            capital_per_pair = total_risk_capital / len(active_pairs)
+            capital_per_pair = equity * cfg.portfolio.risk_per_position_pct
         else:
             capital_per_pair = 0.0
 

--- a/src/coint2/utils/config.py
+++ b/src/coint2/utils/config.py
@@ -21,7 +21,7 @@ class PortfolioConfig(BaseModel):
     """Configuration for portfolio and risk management."""
 
     initial_capital: float
-    risk_per_trade_pct: float
+    risk_per_position_pct: float
     max_active_positions: int
 
 

--- a/tests/core/test_cache.py
+++ b/tests/core/test_cache.py
@@ -30,7 +30,7 @@ def make_cfg(tmp_path: Path, lookback_days: int = 1) -> AppConfig:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/core/test_data_loader.py
+++ b/tests/core/test_data_loader.py
@@ -31,7 +31,7 @@ def test_load_all_data_for_period(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
@@ -82,7 +82,7 @@ def test_load_pair_data(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
@@ -139,7 +139,7 @@ def test_load_and_normalize_data(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
@@ -201,7 +201,7 @@ def test_clear_cache(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(
@@ -277,7 +277,7 @@ def test_fill_limit_pct_application(tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/core/test_file_glob.py
+++ b/tests/core/test_file_glob.py
@@ -27,7 +27,7 @@ def test_rglob_finds_all_files(tmp_path: Path) -> None:
     cfg = AppConfig(
         data_dir=tmp_path,
         results_dir=tmp_path,
-        portfolio=PortfolioConfig(initial_capital=1, risk_per_trade_pct=0.1, max_active_positions=1),
+        portfolio=PortfolioConfig(initial_capital=1, risk_per_position_pct=0.1, max_active_positions=1),
         pair_selection=PairSelectionConfig(
             lookback_days=2,
             coint_pvalue_threshold=0.05,

--- a/tests/core/test_intraday_frequency.py
+++ b/tests/core/test_intraday_frequency.py
@@ -30,7 +30,7 @@ def make_cfg(tmp_path: Path) -> AppConfig:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/pipeline/test_pair_scanner_integration.py
+++ b/tests/pipeline/test_pair_scanner_integration.py
@@ -34,7 +34,7 @@ def test_find_cointegrated_pairs(monkeypatch, tmp_path: Path) -> None:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/pipeline/test_walk_forward.py
+++ b/tests/pipeline/test_walk_forward.py
@@ -49,13 +49,12 @@ def manual_walk_forward(handler: DataHandler, cfg: AppConfig) -> dict:
 
         pairs = [("A", "B", beta, mean, std)]
         active_pairs = pairs[: cfg.portfolio.max_active_positions]
-        total_risk_capital = equity * cfg.portfolio.risk_per_trade_pct
 
         step_pnl = pd.Series(dtype=float)
         total_step_pnl = 0.0
 
         if active_pairs:
-            capital_per_pair = total_risk_capital / len(active_pairs)
+            capital_per_pair = equity * cfg.portfolio.risk_per_position_pct
         else:
             capital_per_pair = 0.0
 
@@ -100,7 +99,7 @@ def test_walk_forward(tmp_path: Path) -> None:
         results_dir=tmp_path / "results",
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -30,7 +30,7 @@ def _create_handler(tmp_path: Path, lookback_days: int = 1) -> DataHandler:
         results_dir=tmp_path,
         portfolio=PortfolioConfig(
             initial_capital=10000.0,
-            risk_per_trade_pct=0.01,
+            risk_per_position_pct=0.01,
             max_active_positions=5,
         ),
         pair_selection=PairSelectionConfig(

--- a/tests/utils/test_config_loading.py
+++ b/tests/utils/test_config_loading.py
@@ -22,7 +22,7 @@ def test_load_config():
     assert cfg.backtest.slippage_pct == 0.0005
     assert cfg.backtest.annualizing_factor == 365
     assert cfg.portfolio.initial_capital == 10000.0
-    assert cfg.portfolio.risk_per_trade_pct == 0.01
+    assert cfg.portfolio.risk_per_position_pct == 0.01
     assert cfg.portfolio.max_active_positions == 5
 
 


### PR DESCRIPTION
## Summary
- rename `risk_per_trade_pct` to `risk_per_position_pct`
- fix capital allocation logic in walk forward orchestrator to allocate fixed risk per pair
- update configuration and tests for the new field name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, dask)*

------
https://chatgpt.com/codex/tasks/task_e_6861100c036c8331981a226b7fa22b20